### PR TITLE
pin dependency `moment` to 2.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "extendscript-es5-shim": "^0.2.0",
-    "moment": "^2.24.0",
+    "moment": "2.24.0",
     "extendscript-logger": "^0.3.0"
   },
   "keywords": [


### PR DESCRIPTION
somewhere in (2.24.0, 2.25.1] the `moment.js` introduced nested ternary operators without parentheses, which trigger a [bug in ExtendScript].

[bug in ExtendScript]: https://community.adobe.com/t5/after-effects/extendscript-throws-on-nested-ternary-operator/td-p/9574014